### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that interacts with the Twitch API. This server utilizes the Twitch Helix API to retrieve channel information, stream details, game data, and more.
 
+<a href="https://glama.ai/mcp/servers/1pub2f29fy"><img width="380" height="200" src="https://glama.ai/mcp/servers/1pub2f29fy/badge" alt="Twitch Server MCP server" /></a>
+
 ## Features
 
 - Get channel information (profile, description, creation date, etc.)


### PR DESCRIPTION
This PR adds a badge for the [Twitch MCP Server](https://glama.ai/mcp/servers/1pub2f29fy) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/1pub2f29fy"><img width="380" height="200" src="https://glama.ai/mcp/servers/1pub2f29fy/badge" alt="Twitch Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.